### PR TITLE
fix: Display account code in recovery email body

### DIFF
--- a/email-wallet/packages/relayer/eml_templates/account_recovery.html
+++ b/email-wallet/packages/relayer/eml_templates/account_recovery.html
@@ -166,7 +166,19 @@
                             margin-bottom: 15px;
                           "
                         >
-                          You may use this button to login on any browser.
+                          Your account code is: <strong style="color: #7649e0; font-family: monospace; font-size: 16px;">{{accountCode}}</strong>
+                        </p>
+                        <p
+                          style="
+                            font-family: 'Regola', sans-serif;
+                            font-size: 14px;
+                            font-weight: normal;
+                            margin: 0;
+                            margin-bottom: 15px;
+                            color: #666;
+                          "
+                        >
+                          Keep this code in a safe place. You may use this button to login on any browser.
                         </p>
                         <p
                           style="


### PR DESCRIPTION
## Summary
- Fixed account recovery email template to display account code in email body
- Account code now appears as visible styled text in the email content
- Maintains existing login button functionality with account code in URL

## Changes Made
- Modified `/email-wallet/packages/relayer/eml_templates/account_recovery.html`
- Added visible account code display: `Your account code is: {{accountCode}}`
- Applied consistent styling with purple color and monospace font

## Problem Solved
Previously, recovery emails only included the account code in the login button URL parameter, making it invisible to users. Users reported receiving emails without visible account codes, making manual account recovery difficult.

## Test Plan
- [ ] Deploy modified template to relayer
- [ ] Send test recovery email
- [ ] Verify account code appears in email body
- [ ] Verify login button still functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)