### PR TITLE
feat: Transform homepage to welcome page and remove ETH support

### DIFF
--- a/frontend/src/app/address/page.tsx
+++ b/frontend/src/app/address/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ethers } from "ethers";
-import { saveEmail, getSavedEmail, saveWalletAddress, getSavedWalletAddress } from "@/lib/localStorage";
+import { getSavedEmail, saveWalletAddress } from "@/lib/localStorage";
 
 // ERC20 ABI (minimal)
 const ERC20_ABI = [
@@ -18,11 +18,10 @@ export default function AddressWalletPage() {
   const [recipientEmail, setRecipientEmail] = useState("");
   const [amount, setAmount] = useState("10");
   const tokenOptions = useMemo(() => [
-    { symbol: "ETH", address: "native", name: "Ethereum", decimals: 18 },
     { symbol: "USDC", address: "0x3CA50b9B421646D0B485852A14168Aa8494D2877", name: "USDC", decimals: 6 },
     { symbol: "JPYC", address: "0x36e3495B2AeC55647bEF00968507366f1f7572C6", name: "JPYC", decimals: 18 },
   ] as const, []);
-  const [token, setToken] = useState<"ETH" | "USDC" | "JPYC">("USDC");
+  const [token, setToken] = useState<"USDC" | "JPYC">("USDC");
   const [status, setStatus] = useState<string>("");
   
   // Wallet related state
@@ -149,15 +148,9 @@ export default function AddressWalletPage() {
 
     try {
       const provider = new ethers.BrowserProvider(window.ethereum!);
-      
-      if (selectedToken.symbol === 'ETH') {
-        const balance = await provider.getBalance(walletAddress);
-        setBalance(ethers.formatEther(balance));
-      } else {
-        const contract = new ethers.Contract(selectedToken.address, ERC20_ABI, provider);
-        const balance = await contract.balanceOf(walletAddress);
-        setBalance(ethers.formatUnits(balance, selectedToken.decimals));
-      }
+      const contract = new ethers.Contract(selectedToken.address, ERC20_ABI, provider);
+      const balance = await contract.balanceOf(walletAddress);
+      setBalance(ethers.formatUnits(balance, selectedToken.decimals));
     } catch (error) {
       console.error('Balance fetch error:', error);
       setBalance('0');
@@ -186,7 +179,7 @@ export default function AddressWalletPage() {
         body: JSON.stringify({
           senderAddress: walletAddress,
           amount: parseFloat(amount),
-          tokenAddress: selectedToken.symbol === 'ETH' ? 'native' : selectedToken.address,
+          tokenAddress: selectedToken.address,
           recipientEmail: recipientEmail,
           expiryTime: Math.floor(Date.now() / 1000) + (30 * 24 * 60 * 60), // 30 days later
         }),
@@ -351,7 +344,7 @@ export default function AddressWalletPage() {
                 </div>
                 
                 {/* Token Address Display */}
-                {token !== "ETH" && (
+                {selectedToken && (
                   <div className="mt-4 p-3 rounded-lg" style={{ background: 'var(--accent-light)', border: '1px solid var(--border-soft)' }}>
                     <div className="flex items-center justify-between">
                       <div className="flex-1">
@@ -451,7 +444,7 @@ export default function AddressWalletPage() {
                 <div>2. Relayer registers as UnclaimedFund</div>
                 <div>3. Send claim notification email to recipient</div>
                 <div>4. Recipient replies to email to claim</div>
-                <div>5. Relayer transfers tokens to recipient's EmailWallet</div>
+                <div>5. Relayer transfers tokens to recipient&apos;s EmailWallet</div>
               </div>
             </div>
           </div>

--- a/frontend/src/app/balance/get/page.tsx
+++ b/frontend/src/app/balance/get/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState, useEffect } from "react";
 import { recoverAccountCode } from "@/lib/relayer";
-import { saveEmail, getSavedEmail } from "@/lib/localStorage";
+import { getSavedEmail } from "@/lib/localStorage";
 
 export default function BalanceGetPage() {
   const [email, setEmail] = useState("");

--- a/frontend/src/app/balance/page.tsx
+++ b/frontend/src/app/balance/page.tsx
@@ -41,16 +41,6 @@ function BalanceContent() {
     const newBalances: TokenBalance[] = [];
 
     try {
-      // ETH balance check
-      const ethBalance = await provider.getBalance(address);
-      newBalances.push({
-        symbol: "ETH",
-        name: "Ethereum",
-        balance: ethers.formatEther(ethBalance),
-        decimals: 18,
-        address: "native"
-      });
-
       // ERC20 token balance check
       for (const token of tokenAddresses) {
         try {
@@ -259,18 +249,14 @@ function BalanceContent() {
                 <div key={index} className="flex items-center justify-between p-4 rounded-lg hover:opacity-80 transition-opacity cursor-pointer" 
                   style={{ background: 'var(--accent-light)', border: '1px solid var(--border-soft)' }}
                   onClick={() => {
-                    if (token.address !== 'native') {
-                      window.open(`https://sepolia.basescan.org/token/${token.address}`, '_blank');
-                    } else {
-                      window.open(`https://sepolia.basescan.org/address/${walletAddress}`, '_blank');
-                    }
+                    window.open(`https://sepolia.basescan.org/token/${token.address}`, '_blank');
                   }}
                   title={`View ${token.name} details`}
                 >
                   <div className="flex items-center gap-3">
                     <div className="w-10 h-10 rounded-full flex items-center justify-center text-xl"
                       style={{ background: 'var(--primary)', color: '#fff' }}>
-                      {token.symbol === 'ETH' ? '⟠' : token.symbol === 'USDC' ? '💰' : token.symbol === 'JPYC' ? '¥' : '🪙'}
+                      {token.symbol === 'USDC' ? '💰' : token.symbol === 'JPYC' ? '¥' : '🪙'}
                     </div>
                     <div>
                       <div className="font-semibold text-base">{token.symbol}</div>

--- a/frontend/src/app/faucet/page.tsx
+++ b/frontend/src/app/faucet/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState, useEffect } from "react";
-import { saveEmail, getSavedEmail } from "@/lib/localStorage";
+import { getSavedEmail } from "@/lib/localStorage";
 
 export default function FaucetPage() {
   const [email, setEmail] = useState("");
@@ -206,7 +206,7 @@ export default function FaucetPage() {
             </h3>
             <div className="space-y-2 text-sm" style={{ color: 'var(--foreground)', opacity: 0.8 }}>
               <div>1. Enter your email address above</div>
-              <div>2. Click the "Claim USDC" button</div>
+              <div>2. Click the &quot;Claim USDC&quot; button</div>
               <div>3. A claim notification will be sent via email</div>
               <div>4. Reply to the email to claim your USDC</div>
             </div>

--- a/frontend/src/app/send/page.tsx
+++ b/frontend/src/app/send/page.tsx
@@ -8,11 +8,10 @@ export default function SendPage() {
   const [email, setEmail] = useState("");
   const [amount, setAmount] = useState("10");
   const tokenOptions = [
-    { symbol: "ETH", address: "native", name: "Ethereum" },
     { symbol: "USDC", address: "0x3CA50b9B421646D0B485852A14168Aa8494D2877", name: "USD Coin" },
     { symbol: "JPYC", address: "0x36e3495B2AeC55647bEF00968507366f1f7572C6", name: "JPYC" },
   ] as const;
-  const [token, setToken] = useState<(typeof tokenOptions)[number]["symbol"]>("ETH");
+  const [token, setToken] = useState<(typeof tokenOptions)[number]["symbol"]>("USDC");
   const [recipient, setRecipient] = useState("");
   const [isRecipientEmail, setIsRecipientEmail] = useState(true);
   const [status, setStatus] = useState<string>("");
@@ -166,7 +165,7 @@ export default function SendPage() {
             </div>
             
             {/* Token Address Display */}
-            {token !== "ETH" && (
+            {tokenOptions.find(t => t.symbol === token) && (
               <div className="mt-4 p-3 rounded-lg" style={{ background: 'var(--accent-light)', border: '1px solid var(--border-soft)' }}>
                 <div className="flex items-center justify-between">
                   <div className="flex-1">

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -17,7 +17,6 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/faucet", label: "USDC Faucet", icon: "💰" },
   { href: "/balance/get", label: "Balance Email", icon: "📧" },
   { href: "/balance", label: "Balance View", icon: "💼" },
-  { href: "/other", label: "Other", icon: "🧰" },
 ];
 
 const NAV_DAPPS: NavItem[] = [


### PR DESCRIPTION
## Summary
- Transform homepage from "Other" to "Welcome" page with improved UX
- Add real-time account verification using same logic as send page
- Auto-redirect existing users to send page with saved email
- Remove ETH token support from all pages (send, balance, address) 
- Restrict to USDC and JPYC tokens only
- Update token selection defaults to USDC

## Changes
### Welcome Page Improvements
- Convert `/` route from "Other" to "Welcome" page
- Add real-time email verification with visual feedback
- Dynamic button text: "Send Me an Invitation" vs "Go to Send Page"
- Auto-save email to localStorage and redirect existing users

### ETH Token Removal
- Remove ETH from token options in send, balance, and address pages
- Update default token selection to USDC
- Remove ETH-specific balance checking and transfer logic
- Simplify token address display logic

### Bug Fixes
- Fix ESLint warnings and build errors
- Remove unused imports and variables
- Fix unescaped quotes in JSX

## Test plan
- [x] Build passes without errors
- [x] Welcome page shows real-time verification
- [x] Existing users auto-redirect to send page
- [x] New users can request invitation emails
- [x] Only USDC and JPYC tokens available
- [x] All pages work without ETH support

🤖 Generated with [Claude Code](https://claude.ai/code)