### PR TITLE
Fix frontend build errors

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { createAccount, isAccountCreated } from "@/lib/relayer";
+import { createAccount } from "@/lib/relayer";
 import { saveEmail, getSavedEmail } from "@/lib/localStorage";
 
 export default function WelcomePage() {

--- a/frontend/src/app/send/page.tsx
+++ b/frontend/src/app/send/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { createAccount, send } from "@/lib/relayer";
 import { saveEmail, getSavedEmail } from "@/lib/localStorage";
 
-export default function SendPage() {
+function SendPageContent() {
   const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
   const [amount, setAmount] = useState("10");
@@ -318,5 +318,13 @@ export default function SendPage() {
       
       {/* navigation links are centralized in the hamburger menu */}
     </main>
+  );
+}
+
+export default function SendPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SendPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- Resolve Next.js 15 CSR bailout warning by wrapping useSearchParams in Suspense boundary
- Remove unused isAccountCreated import to eliminate lint warning

## Changes
- **SendPage**: Wrap `useSearchParams()` in Suspense boundary to comply with Next.js 15 requirements
- **HomePage**: Remove unused `isAccountCreated` import to fix lint warning
- Restructure SendPage component to separate content from Suspense wrapper

## Test plan
- [x] Frontend build passes without errors
- [x] All static pages generate successfully
- [x] No lint warnings in modified files

🤖 Generated with [Claude Code](https://claude.ai/code)